### PR TITLE
readme: update instructions for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Required dependencies:
 * Node 16.7+
 * Yarn
 * Latest Rust (including wasm toolchain: `rustup target add wasm32-unknown-unknown`)
+* Perl (on Windows you can use [Strawberry Perl](https://strawberryperl.com/))
 * wrangler: `cargo install wrangler`
 * TrunkRS: `cargo install trunk`
 * worker-build: `cargo install worker-build`


### PR DESCRIPTION
Hello ! Installing Wrangler on Windows only works if Perl has been installed (should be installed by default on Unix systems).
I added a link to a working Windows Perl distribution in the readme.