### PR TITLE
readme: update dependency installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,8 @@ Required dependencies:
 * Node 16.7+
 * Yarn
 * Latest Rust (including wasm toolchain: `rustup target add wasm32-unknown-unknown`)
-* wrangler: `cargo install wrangler`
 * TrunkRS: `cargo install trunk`
-* worker-build: `cargo install worker-build`
-* wasm-pack: `cargo install wasm-pack`
+* worker-build: `cargo install --git https://github.com/Dav1dde/workers-rs.git --branch pobbin worker-build`
 
 The application can be started with:
 


### PR DESCRIPTION
The project doesnt build without the forked worker-build, wrangler is not needed
(and the one in cargo do not even compiles anymore), and neither is wasm-pack,
both are installed during build.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>

Closes #47 
