### PR TITLE
pob: add support for loadout selection

### DIFF
--- a/app/src/build.rs
+++ b/app/src/build.rs
@@ -11,6 +11,9 @@ pub struct Build {
     data: data::Data,
 
     active_tree: RcSignal<usize>,
+    active_item_set: RcSignal<usize>,
+    active_skill_set: RcSignal<usize>,
+    loadouts: Vec<pob::Loadout>,
 }
 
 impl Build {
@@ -25,6 +28,40 @@ impl Build {
     pub fn active_tree(&self) -> &RcSignal<usize> {
         &self.active_tree
     }
+
+    pub fn active_item_set(&self) -> &RcSignal<usize> {
+        &self.active_item_set
+    }
+
+    pub fn active_skill_set(&self) -> &RcSignal<usize> {
+        &self.active_skill_set
+    }
+
+    pub fn loadouts(&self) -> &[pob::Loadout] {
+        &self.loadouts
+    }
+
+    pub fn selected_loadout_index(&self) -> Option<usize> {
+        let tree = *self.active_tree.get();
+        let item_set = *self.active_item_set.get();
+        let skill_set = *self.active_skill_set.get();
+
+        self.loadouts.iter().position(|loadout| {
+            loadout.tree_index == tree
+                && loadout.item_set_index == item_set
+                && loadout.skill_set_index == skill_set
+        })
+    }
+
+    pub fn select_loadout(&self, index: usize) {
+        let Some(loadout) = self.loadouts.get(index) else {
+            return;
+        };
+
+        self.active_tree.set(loadout.tree_index);
+        self.active_item_set.set(loadout.item_set_index);
+        self.active_skill_set.set(loadout.skill_set_index);
+    }
 }
 
 impl Build {
@@ -37,12 +74,26 @@ impl Build {
             .iter()
             .position(|spec| spec.active)
             .unwrap_or(0);
+        let active_item_set = pob
+            .item_sets()
+            .iter()
+            .position(|set| set.is_selected)
+            .unwrap_or(0);
+        let active_skill_set = pob
+            .skill_sets()
+            .iter()
+            .position(|set| set.is_selected)
+            .unwrap_or(0);
+        let loadouts = pob.loadouts();
 
         Ok(Self {
             content,
             pob,
             data,
             active_tree: create_rc_signal(active_tree),
+            active_item_set: create_rc_signal(active_item_set),
+            active_skill_set: create_rc_signal(active_skill_set),
+            loadouts,
         })
     }
 

--- a/app/src/components/pob_gear_preview.rs
+++ b/app/src/components/pob_gear_preview.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use pob::PathOfBuilding;
 use sycamore::prelude::*;
 use wasm_bindgen::JsCast;
@@ -22,31 +21,38 @@ pub fn PobGearPreview<'a, G: Html>(cx: Scope<'a>, build: &'a Build) -> View<G> {
 
     let item_sets = create_ref(cx, build.item_sets());
 
-    let item_set = item_sets.iter().find_or_first(|set| set.is_selected);
-    let item_set = create_signal(cx, item_set);
+    let options = create_ref(
+        cx,
+        item_sets
+            .iter()
+            .map(|item_set| {
+                item_set
+                    .title
+                    .map(|s| s.to_owned())
+                    .unwrap_or_else(|| item_set.id.to_string())
+            })
+            .collect::<Vec<_>>(),
+    );
 
-    let options = item_sets
-        .iter()
-        .map(|item_set| {
-            item_set
-                .title
-                .map(|s| s.to_owned())
-                .unwrap_or_else(|| item_set.id.to_string())
-        })
-        .collect();
-
-    let selected = item_sets.iter().position(|set| set.is_selected);
     let on_change = move |index| {
         let Some(index) = index else { return };
-        item_set.set(item_sets.get(index));
+        build.active_item_set().set(index);
     };
 
+    let select = create_memo(cx, move || {
+        let selected = Some(*build.active_item_set().get());
+        view! { cx,
+            PobColoredSelect(options=(*options).clone(), selected=selected, label="Select gear set", on_change=on_change)
+        }
+    });
+
     let items = create_memo(cx, move || {
-        let item_set = item_set.get();
+        let index = *build.active_item_set().get();
+        let item_set = item_sets.get(index);
         view! { cx,
             PobItemSet(
                 build_=build,
-                item_set=*item_set,
+                item_set=item_set,
                 current_item=current_item,
             )
         }
@@ -71,7 +77,7 @@ pub fn PobGearPreview<'a, G: Html>(cx: Scope<'a>, build: &'a Build) -> View<G> {
     view! { cx,
         Popup(attach=attach, parent=None) { (&*popup.get()) }
         div(class=select_classes) {
-            PobColoredSelect(options=options, selected=selected, label="Select gear set", on_change=on_change)
+            (&*select.get())
         }
         div(class="flex flex-col justify-center mt-5 sm:px-3",
             on:mouseover=mouseover,

--- a/app/src/components/pob_gems.rs
+++ b/app/src/components/pob_gems.rs
@@ -25,25 +25,45 @@ pub fn PobGems<'a, G: Html>(cx: Scope<'a>, build: &'a Build) -> View<G> {
 
     let content = create_signal(cx, view! { cx, });
 
-    let options = skill_sets
-        .iter()
-        .map(|ss| {
-            ss.title
-                .map(|s| s.to_owned())
-                .unwrap_or_else(|| ss.id.to_string())
-        })
-        .collect();
-    let selected = skill_sets.iter().position(|ss| ss.is_selected);
+    let options = create_ref(
+        cx,
+        skill_sets
+            .iter()
+            .map(|ss| {
+                ss.title
+                    .map(|s| s.to_owned())
+                    .unwrap_or_else(|| ss.id.to_string())
+            })
+            .collect::<Vec<_>>(),
+    );
     let on_change = move |index| {
         let Some(index) = index else { return };
-        if let Some(ss) = build.skill_sets().into_iter().nth(index) {
-            content.set(render_skills::<G>(cx, ss.skills, build.data()));
-        }
+        build.active_skill_set().set(index);
     };
 
-    if let Some(ss) = skill_sets.into_iter().find(|ss| ss.is_selected) {
-        content.set(render_skills(cx, ss.skills, build.data()));
-    }
+    create_effect(cx, move || {
+        let index = *build.active_skill_set().get();
+        let selected = build
+            .skill_sets()
+            .into_iter()
+            .nth(index)
+            .or_else(|| build.skill_sets().into_iter().next());
+
+        if let Some(ss) = selected {
+            content.set(render_skills(cx, ss.skills, build.data()));
+        } else {
+            content.set(view! { cx, });
+        }
+    });
+
+    let select = create_memo(cx, move || {
+        let selected = Some(*build.active_skill_set().get());
+        view! { cx,
+            div(class="-mb-5") {
+                PobColoredSelect(options=(*options).clone(), selected=selected, label="Select skill set", on_change=on_change)
+            }
+        }
+    });
 
     let attach = create_signal(cx, None);
     let popup = create_signal(cx, View::default());
@@ -66,13 +86,7 @@ pub fn PobGems<'a, G: Html>(cx: Scope<'a>, build: &'a Build) -> View<G> {
     let mouseout = |_: web_sys::Event| attach.set(None);
 
     let select = match show_select {
-        true => {
-            view! { cx,
-                div(class="-mb-5") {
-                    PobColoredSelect(options=options, selected=selected, label="Select skill set", on_change=on_change)
-                }
-            }
-        }
+        true => view! { cx, (&*select.get()) },
         false => View::default(),
     };
 

--- a/app/src/components/pob_tree_preview.rs
+++ b/app/src/components/pob_tree_preview.rs
@@ -75,6 +75,12 @@ pub fn PobTreePreview<'a, G: Html>(cx: Scope<'a>, build: &'a Build) -> View<G> {
 
     let trees = create_ref(cx, trees);
     let current_tree = create_signal(cx, trees.iter().find_or_first(|t| t.spec.active).unwrap());
+    create_effect(cx, move || {
+        let index = *build.active_tree().get();
+        if let Some(tree) = trees.get(index).or_else(|| trees.first()) {
+            current_tree.set(tree);
+        }
+    });
     let tree_loaded = create_signal(cx, false);
     let node_ref = create_node_ref(cx);
 
@@ -143,11 +149,16 @@ pub fn PobTreePreview<'a, G: Html>(cx: Scope<'a>, build: &'a Build) -> View<G> {
         });
     });
 
-    // TODO: this updates the currently active tree, but it doesn't read from it
-    // the select would need to be updated as well if the tree changes, kinda tricky...
-    let select = render_select(cx, trees, move |index, tree| {
-        current_tree.set(tree);
-        build.active_tree().set(index);
+    let select = create_memo(cx, move || {
+        render_select(
+            cx,
+            trees,
+            Some(*build.active_tree().get()),
+            move |index, tree| {
+                current_tree.set(tree);
+                build.active_tree().set(index);
+            },
+        )
     });
 
     let nodes = create_memo(cx, move || render_nodes(cx, gv, &current_tree.get()));
@@ -190,7 +201,7 @@ pub fn PobTreePreview<'a, G: Html>(cx: Scope<'a>, build: &'a Build) -> View<G> {
     view! { cx,
         Popup(attach=attach, parent=Some(node_ref)) { (&*popup.get()) }
         div(class="flex flex-wrap align-center") {
-            div(class="h-9 max-w-full") { (select) }
+            div(class="h-9 max-w-full") { (&*select.get()) }
             div(class="flex-1 text-right sm:mr-3 whitespace-nowrap") { (&*tree_level.get()) }
         }
         div(class="grid grid-cols-10 gap-3") {
@@ -429,6 +440,7 @@ fn render_mastery<G: GenericNode + Html>(cx: Scope, gv: GameVersion, node: &data
 fn render_select<'a, G: GenericNode + Html, F>(
     cx: Scope<'a>,
     trees: &'a [Tree],
+    selected: Option<usize>,
     on_change: F,
 ) -> View<G>
 where
@@ -439,7 +451,6 @@ where
     }
 
     let options = trees.iter().map(|t| t.name.clone()).collect();
-    let selected = trees.iter().position(|t| t.spec.active);
     let on_change = move |index| {
         if let Some(index) = index {
             on_change(index, &trees[index])

--- a/app/src/components/view_paste.rs
+++ b/app/src/components/view_paste.rs
@@ -7,7 +7,7 @@ use web_sys::HtmlTextAreaElement;
 use super::PobGearPreview;
 use crate::{
     build::Build,
-    components::{PobColoredText, PobGems, PobTreePreview},
+    components::{PobColoredSelect, PobColoredText, PobGems, PobTreePreview},
     consts::{IMG_ONERROR_HIDDEN, SELF_URL},
     pob::{self, Element},
     storage::Storage,
@@ -86,6 +86,42 @@ pub fn ViewPaste<'a, G: Html>(
             PobTreePreview(build)
         }
     });
+
+    let loadout_select = if build.loadouts().len() > 1 {
+        let loadout_options = create_ref(
+            cx,
+            build
+                .loadouts()
+                .iter()
+                .map(|loadout| loadout.name.clone())
+                .collect::<Vec<_>>(),
+        );
+        let on_change = move |index: Option<usize>| {
+            let Some(index) = index.and_then(|index| index.checked_sub(1)) else {
+                return;
+            };
+            build.select_loadout(index);
+        };
+        let select = create_memo(cx, move || {
+            let mut options = Vec::with_capacity(loadout_options.len() + 1);
+            options.push("Custom".to_owned());
+            options.extend_from_slice(loadout_options);
+
+            let selected = build.selected_loadout_index().map(|index| index + 1);
+            view! { cx,
+                PobColoredSelect(options=options, selected=selected, label="Select loadout", on_change=on_change)
+            }
+        });
+
+        view! { cx,
+            div(class="mb-8") {
+                h2(class="text-lg dark:text-slate-100 text-slate-900 mb-2 border-b border-solid") { "Loadout" }
+                (&*select.get())
+            }
+        }
+    } else {
+        View::empty()
+    };
 
     let select_all = |event: web_sys::Event| {
         let s: HtmlTextAreaElement = event.target().unwrap().unchecked_into();
@@ -192,6 +228,7 @@ pub fn ViewPaste<'a, G: Html>(
                 }
             }
         }
+        (loadout_select)
         div(class="flex flex-wrap gap-x-10 gap-y-16") {
             div(class="flex-auto w-60") {
                 h2(class="text-lg dark:text-slate-100 text-slate-900 mb-2 border-b border-solid") { "Gear" }

--- a/pob/src/lib.rs
+++ b/pob/src/lib.rs
@@ -87,6 +87,14 @@ pub struct SkillSet<'a> {
     pub is_selected: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Loadout {
+    pub name: String,
+    pub tree_index: usize,
+    pub item_set_index: usize,
+    pub skill_set_index: usize,
+}
+
 #[derive(Debug)]
 pub struct Skill<'a> {
     pub is_selected: bool,

--- a/pob/src/serde/pob.rs
+++ b/pob/src/serde/pob.rs
@@ -40,6 +40,141 @@ impl SerdePathOfBuilding {
         Self::from_xml(&data)
     }
 
+    pub fn loadouts(&self) -> Vec<crate::Loadout> {
+        use std::collections::HashMap;
+
+        let trees = &self.pob.tree.specs;
+        let item_sets = &self.pob.items.item_sets;
+        let skill_sets = &self.pob.skills.skill_sets;
+
+        if trees.is_empty() || item_sets.is_empty() || skill_sets.is_empty() {
+            return Vec::new();
+        }
+
+        #[derive(Debug)]
+        struct TreeLink {
+            tree_index: usize,
+            title: String,
+            link_id: String,
+        }
+
+        fn default_title(title: Option<&str>) -> &str {
+            title.unwrap_or("Default")
+        }
+
+        fn parse_loadout_link(title: &str) -> Option<Vec<&str>> {
+            let mut search = 0;
+            while let Some(rel_start) = title[search..].find('{') {
+                let start = search + rel_start;
+                let Some(rel_end) = title[start + 1..].find('}') else {
+                    break;
+                };
+                let end = start + 1 + rel_end;
+                let link_ids = &title[start + 1..end];
+                if link_ids.is_empty()
+                    || !link_ids
+                        .bytes()
+                        .all(|byte| byte.is_ascii_alphanumeric() || byte == b',')
+                {
+                    search = start + 1;
+                    continue;
+                }
+
+                return Some(link_ids.split(',').filter(|id| !id.is_empty()).collect());
+            }
+
+            None
+        }
+
+        fn identify_links<'a, T, F>(
+            sets: &'a [T],
+            title: F,
+        ) -> (HashMap<String, usize>, HashMap<String, usize>)
+        where
+            F: Fn(&'a T) -> Option<&'a str>,
+        {
+            let mut exact = HashMap::new();
+            let mut special = HashMap::new();
+
+            for (index, set) in sets.iter().enumerate() {
+                let title = default_title(title(set));
+                if let Some(link_ids) = parse_loadout_link(title) {
+                    for link_id in link_ids {
+                        special.insert(link_id.to_owned(), index);
+                    }
+                } else {
+                    exact.entry(title.to_owned()).or_insert(index);
+                }
+            }
+
+            (exact, special)
+        }
+
+        // Returns index 0 when there is only one set, otherwise looks up the key.
+        let resolve = |one: bool, map: &HashMap<String, usize>, key: &str| -> usize {
+            if one {
+                0
+            } else {
+                *map.get(key).unwrap()
+            }
+        };
+
+        let one_item = item_sets.len() <= 1;
+        let one_skill = skill_sets.len() <= 1;
+
+        let mut tree_list = Vec::new();
+        let mut tree_links = Vec::new();
+
+        for (index, spec) in trees.iter().enumerate() {
+            let title = default_title(spec.title.as_deref());
+            if let Some(link_ids) = parse_loadout_link(title) {
+                for link_id in link_ids {
+                    tree_links.push(TreeLink {
+                        tree_index: index,
+                        title: title.to_owned(),
+                        link_id: link_id.to_owned(),
+                    });
+                }
+            } else {
+                tree_list.push((title.to_owned(), index));
+            }
+        }
+
+        let (item_exact, item_special) = identify_links(item_sets, |set| set.title.as_deref());
+        let (skill_exact, skill_special) = identify_links(skill_sets, |set| set.title.as_deref());
+
+        let mut loadouts = Vec::new();
+
+        for (tree_name, tree_index) in tree_list {
+            if (one_item || item_exact.contains_key(&tree_name))
+                && (one_skill || skill_exact.contains_key(&tree_name))
+            {
+                loadouts.push(crate::Loadout {
+                    name: tree_name.clone(),
+                    tree_index,
+                    item_set_index: resolve(one_item, &item_exact, &tree_name),
+                    skill_set_index: resolve(one_skill, &skill_exact, &tree_name),
+                });
+            }
+        }
+
+        for tree_link in tree_links {
+            let id = &tree_link.link_id;
+            if (one_item || item_special.contains_key(id))
+                && (one_skill || skill_special.contains_key(id))
+            {
+                loadouts.push(crate::Loadout {
+                    name: tree_link.title,
+                    tree_index: tree_link.tree_index,
+                    item_set_index: resolve(one_item, &item_special, id),
+                    skill_set_index: resolve(one_skill, &skill_special, id),
+                });
+            }
+        }
+
+        loadouts
+    }
+
     fn main_skill(&self) -> Option<&Skill> {
         let mut index = self.pob.build.main_socket_group as usize;
         if index < 1 {
@@ -573,5 +708,66 @@ mod tests {
     fn parse_v325_loadouts() {
         let pob = SerdePathOfBuilding::from_xml(V325_LOADOUTS).unwrap();
         assert!(pob.config(Config::PowerCharges).is_true());
+
+        let loadouts = pob.loadouts();
+        assert_eq!(2, loadouts.len());
+        assert_eq!("Default", loadouts[0].name);
+        assert_eq!("test", loadouts[1].name);
+        assert_eq!(1, loadouts[1].tree_index);
+        assert_eq!(1, loadouts[1].item_set_index);
+        assert_eq!(1, loadouts[1].skill_set_index);
+    }
+
+    #[test]
+    fn parse_grouped_loadouts() {
+        static XML: &str = r#"
+<PathOfBuilding>
+    <Build level="1" targetVersion="3_0" className="Scion" ascendClassName="None" mainSocketGroup="1">
+        <PlayerStat stat="AverageDamage" value="1"/>
+    </Build>
+    <Tree activeSpec="1">
+        <Spec title="Leveling {lv}" treeVersion="3_25" classId="0" ascendClassId="0" secondaryAscendClassId="nil" nodes="58833">
+            <URL>https://www.pathofexile.com/passive-skill-tree/AAAABgAAAAAA</URL>
+            <Sockets/>
+            <Overrides/>
+        </Spec>
+        <Spec title="Maps {map}" treeVersion="3_25" classId="0" ascendClassId="0" secondaryAscendClassId="nil" nodes="58833">
+            <URL>https://www.pathofexile.com/passive-skill-tree/AAAABgAAAAAA</URL>
+            <Sockets/>
+            <Overrides/>
+        </Spec>
+    </Tree>
+    <Notes/>
+    <Skills activeSkillSet="1">
+        <SkillSet id="1" title="Main Skills">
+            <Skill enabled="true" mainActiveSkill="1">
+                <Gem nameSpec="Arc" skillId="Arc" gemId="Metadata/Items/Gems/SkillGemArc" level="1" quality="0"/>
+            </Skill>
+        </SkillSet>
+    </Skills>
+    <Items activeItemSet="1">
+        <ItemSet id="1" title="Gear {lv}"/>
+        <ItemSet id="2" title="Gear {map}"/>
+    </Items>
+    <Config activeConfigSet="2">
+        <ConfigSet id="1" title="Config {lv}"/>
+        <ConfigSet id="2" title="Config {map}"/>
+    </Config>
+</PathOfBuilding>
+        "#;
+
+        let pob = SerdePathOfBuilding::from_xml(XML).unwrap();
+        let loadouts = pob.loadouts();
+        assert_eq!(
+            vec!["Leveling {lv}".to_owned(), "Maps {map}".to_owned()],
+            loadouts
+                .iter()
+                .map(|loadout| loadout.name.clone())
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(0, loadouts[0].item_set_index);
+        assert_eq!(0, loadouts[0].skill_set_index);
+        assert_eq!(1, loadouts[1].item_set_index);
+        assert_eq!(0, loadouts[1].skill_set_index);
     }
 }


### PR DESCRIPTION
Adds support for loadout selector that is hidden when
there is only one/zero loadouts.

Closes #43

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>
